### PR TITLE
feat(mood): add import endpoint with deduplication by client_id

### DIFF
--- a/app/models/mood_entry.py
+++ b/app/models/mood_entry.py
@@ -6,6 +6,7 @@ from app.models.user import User
 
 
 class MoodEntry(Document):
+    client_id: str
     user: Link[User]
     mood_score: int = Field(..., ge=1, le=10)
     emotions: List[str]  # חובה - חייב להזין רגשות

--- a/app/schemas/mood_entry.py
+++ b/app/schemas/mood_entry.py
@@ -4,6 +4,7 @@ from datetime import datetime
 
 
 class MoodEntryCreate(BaseModel):
+    id: str
     mood_score: int = Field(..., ge=1, le=10)
     emotions: List[str]
     reasons: Optional[List[str]] = None


### PR DESCRIPTION
- מסלול חדש POST /mood/import המאפשר למשתמש מחובר לייבא רשומות מצב רוח מקובץ JSON (ממצב אנונימי).
- המזהה הייחודי (UUID) נשמר בשדה client_id, ונעשה סינון של כפילויות כדי למנוע שמירה חוזרת של אותם moods.