### PR TITLE
add user model for google oauth login

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+.venv/Scripts/activate

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -1,0 +1,12 @@
+from datetime import datetime, timezone
+from typing import Optional
+from beanie import Document
+from pydantic import EmailStr, Field
+
+
+class User(Document):
+    email: EmailStr
+    username: str
+    profile_picture: Optional[str] = None
+    is_oauth_user: bool = True
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))


### PR DESCRIPTION
- הוגדר מודל משתמש Beanie עבור התחברות עם Google בלבד.
- כולל שדות אימייל, שם משתמש, תמונת פרופיל, ודגל OAuth. נכתב עם תמיכה ב־timezone, והוכן לשימוש עתידי בהתחברות OAuth.