### PR TITLE
register user model with init_beanie

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,22 @@
+import os
+from beanie import init_beanie
+import dotenv
 from fastapi import FastAPI
+from motor.motor_asyncio import AsyncIOMotorClient
+
+from .models.user import User
+
+dotenv.load_dotenv()
+
+DB_URL = os.getenv("MONGODB_URL")
 
 app = FastAPI()
+
+
+@app.on_event("startup")
+async def connect_to_db():
+    client = AsyncIOMotorClient(DB_URL)
+    await init_beanie(client.get_database(), document_models=[User])
 
 
 @app.get("/")

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ uvicorn[standard]
 beanie
 motor
 python-dotenv
+pydantic[email]


### PR DESCRIPTION
🧩 תיאור הפיצ'ר
רישום מודל User במסד הנתונים עם init_beanie, כהכנה לשלב התחברות באמצעות Google.

✅ מה בוצע
 טעינת משתני סביבה מקובץ .env

 שליפת MONGODB_URL עם os.getenv

 יצירת חיבור למסד באמצעות AsyncIOMotorClient

 רישום המודל User במסד הנתונים עם init_beanie

 הוספת @app.on_event("startup") להרצת ההתחברות בעת הפעלת השרת

🧪 בדיקות שבוצעו
 הרצה מקומית של השרת (uvicorn)

 ווידוא שאין שגיאות התחברות למסד

 בדיקת הופעת הקולקציה users במסד הנתונים

📎 מסמכים נלווים
תיעוד הפיצ'ר: feature_register_user_model.md

סיכום בפרויקט: development_progress_summary.md

שיחה ב־ChatGPT: 0508T00 (המשך לפיצ'ר מודל User)

⏭️ מה השלב הבא?
הוספת OAuth endpoints:

/auth/google/login

/auth/google/callback

